### PR TITLE
Add influxdb2-cli package

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,10 @@ influxdb_dependencies:
   - curl
   - gnupg
 
+influxdb_packages:
+  - influxdb2
+  - influxdb2-cli
+
 influxdb_package_state: present
 
 influxdb_config_path: /etc/influxdb

--- a/molecule/default/tests/test_role.py
+++ b/molecule/default/tests/test_role.py
@@ -115,7 +115,10 @@ def test_influxdb_buckets_exist(host, name, description, org):
     json_data = host.check_output(command)
     items_list = json.loads(json_data)
     for item in items_list:
-        if item['name'] == name and item['description'] == description:
+        if item['name'] == name:
+            if 'description' in item:
+                assert item['description'] == description
+                break
             assert True
             break
     else:

--- a/molecule/default/tests/test_role.py
+++ b/molecule/default/tests/test_role.py
@@ -12,6 +12,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 @pytest.mark.parametrize('name', [
   ('influxdb2'),
+  ('influxdb2-cli'),
 ])
 def test_packages_are_installed(host, name):
     package = host.package(name)

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -20,7 +20,7 @@
   register: _setup
   failed_when:
     - _setup.rc != 0
-    - '"has already been setup" not in _setup.stdout'
+    - '"has already been set up" not in _setup.stderr'
   changed_when: _setup.rc == 0
 
 - name: Ensure organizations exist
@@ -34,7 +34,7 @@
   register: _org
   failed_when:
     - _org.rc != 0
-    - '"already exists" not in _org.stdout'
+    - '"already exists" not in _org.stderr'
   changed_when: _org.rc == 0
 
 - name: Ensure users exist
@@ -49,7 +49,7 @@
   register: _user
   failed_when:
     - _user.rc != 0
-    - '"already exists" not in _user.stdout'
+    - '"already exists" not in _user.stderr'
   changed_when: _user.rc == 0
 
 - name: Ensure buckets exist
@@ -65,5 +65,5 @@
   register: _bucket
   failed_when:
     - _bucket.rc != 0
-    - '"already exists" not in _bucket.stdout'
+    - '"already exists" not in _bucket.stderr'
   changed_when: _bucket.rc == 0

--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -16,11 +16,12 @@
     state: present
   loop: "{{ influxdb_repositories }}"
 
-- name: Ensure InfluxDB package is installed
+- name: Ensure InfluxDB packages are installed
   apt:
-    name: influxdb2
+    name: "{{ item }}"
     state: "{{ influxdb_package_state }}"
     update_cache: true
+  loop: "{{ influxdb_packages }}"
 
 - name: Setup InfluxDB default file
   template:


### PR DESCRIPTION
InfluxDB will [stop packaging](https://github.com/influxdata/influxdb/releases/tag/v2.0.8) `influx` cli command in `influxdb2` Debian package. For this reason we need to specifically install a new package called `influxdb2-cli` as a replacement.