### PR TITLE
Use complete path to config for INFLUXD_CONFIG_PATH

### DIFF
--- a/templates/etc/default/influxdb2.j2
+++ b/templates/etc/default/influxdb2.j2
@@ -1,5 +1,5 @@
 ### {{ ansible_managed }}
 
-INFLUXD_CONFIG_PATH={{ influxdb_config_path }}
+INFLUXD_CONFIG_PATH={{ influxdb_config_path }}/config.yml
 INFLUXD_BOLT_PATH={{ influxdb_bolt_path }}
 INFLUXD_ENGINE_PATH={{ influxdb_engine_path }}


### PR DESCRIPTION
Influxdb also uses the complete path in scripts: https://github.com/influxdata/influxdb/blob/master/scripts/influxdb2-upgrade.sh#L4
This enforces the use of a specific config, and prevents undesired effects when a new influxdb version writes as `config.toml` that takes precedence.